### PR TITLE
Loosen Faraday Version Constraint

### DIFF
--- a/prometheus-api-client.gemspec
+++ b/prometheus-api-client.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
-  s.add_dependency 'faraday', '~> 0.9.2'
+  s.add_dependency 'faraday', '~> 0.9'
 end


### PR DESCRIPTION
**Description**

Faraday Version Constraint is too restrictive.

Fix: https://github.com/prometheus/prometheus_api_client_ruby/issues/12