### PR TITLE
Allow faraday 1.0.0

### DIFF
--- a/prometheus-api-client.gemspec
+++ b/prometheus-api-client.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
-  s.add_dependency 'faraday', '~> 0.9'
+  s.add_dependency 'faraday', '>= 0.9', '< 2.0.0'
 end


### PR DESCRIPTION
[Faraday got updated](https://github.com/lostisland/faraday/pull/1101) and [the manageiq folks](https://github.com/ManageIQ/manageiq/issues/19760) were hoping maybe that you all might be amenable to letting people update so we can support ruby 2.7.

Thanks!